### PR TITLE
为什么我们暂时不能煽动一些违法的东西

### DIFF
--- a/ipc-emulator.txt
+++ b/ipc-emulator.txt
@@ -1,1 +1,1 @@
-sys v ipc emulator: control_pipe_fd = 79, ipc_domain = com.eltechs.ed
+sys v ipc emulator:


### PR DESCRIPTION
现在这个时间点煽动的非蠢即坏

996从根本上是在破坏国家利益...低生育率，生产过剩消费不足，再纵容996扩散到全社会就成了美国大萧条了
//资本家不怕可政府大概怕，至少对顶层来说这不利，我都说了统治阶级内部不是铁板一块，各自利益各不同，就比如说深圳政府还巴不得把阿里巴巴反抗来

还记得当年工人运动的时候资本家在工人中制造流血事件，然后让当局治罪吗，我感觉这个也差不多，一旦某些人的企图成功，这里就会马上404，正好给了个借口
知道的人越多越不容易被维稳，至少也到了热度不能再增长的时候，现在热度还没冷却，先让更多人知道我们，想搞这些至少等热度趋于平稳

国家不发声是不敢动还是憋大招不知道，但是有一点是确定的，这个项目惊醒了千千万万个我，也引起了社会讨论，让很多人意识到996的不合理，这目前就够了

我们很难指望点点鼠标键盘问题就能在一瞬间解决，任何国家任何地区也不会是问题一提出就马上解决，想想这个项目进入公众视野也就7-10天，这个进展算不错的